### PR TITLE
fix: lowercase option keys when validating

### DIFF
--- a/__tests__/validations.test.tsx
+++ b/__tests__/validations.test.tsx
@@ -145,7 +145,7 @@ test('Throw when two options with the same key are being used', () => {
             {
               value: '',
               label: 'Option 2',
-              key: 'sameKey',
+              key: 'sameKEY',
               type: 'TEXT',
             },
           ],

--- a/src/validations/prefab.ts
+++ b/src/validations/prefab.ts
@@ -91,7 +91,7 @@ const validateOptions = ({ structure, name }: Prefab): void => {
     const keys: string[] = [];
 
     options.forEach(({ key }) => {
-      if (keys.includes(key)) {
+      if (keys.map(k => k.toLowerCase()).includes(key.toLowerCase())) {
         throw new Error(
           chalk.red(
             `\nMultiple option references to key: ${key} in prefab: ${name}\n`,


### PR DESCRIPTION
BREAKING CHANGE: Option keys like 'Hello' and 'hELLO' on the same prefab are no longer allowed