### PR TITLE
fix: Add exit code 1 to error of building

### DIFF
--- a/src/bb-components-build.ts
+++ b/src/bb-components-build.ts
@@ -158,6 +158,7 @@ const readInteractions: () => Promise<Interaction[]> = async (): Promise<
 
     console.info(chalk.green('Success, the component set has been built'));
   } catch ({ file, name, message }) {
+    process.exitCode = 1;
     if (file) {
       console.error(chalk.red(`\n${name} in ${file}: ${message}\n`));
     } else {


### PR DESCRIPTION
Currently when building components `bb components build` and it fails with an error like reference to non existing component it still returns exit code 0.

So this is a fix when it errors it returns exit code 1.