### PR TITLE
fix: move husky git message check to correct location

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,5 +1,0 @@
-{
-  "hooks": {
-    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn prettier:check"
+      "pre-commit": "yarn prettier:check",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
While using this library as example for component set implementation for release notes I found out the commit message verification is broken.