### PR TITLE
Fix for endles build loop on npm run dev

### DIFF
--- a/assets/component-set/__package.json
+++ b/assets/component-set/__package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "bb components serve",
     "build": "bb components build",
-    "dev": "nodemon --watch src --exec \"rimraf dist && bb components build && bb components serve\"",
+    "dev": "nodemon --watch src --ignore 'src/interactions/*.js' --exec \"rimraf dist && bb components build && bb components serve\"",
     "preview": "bb components preview",
     "lint": "eslint --ext js ./src"
   },


### PR DESCRIPTION
If you do ‘npm run dev’ when there is a interaction in src/interactions you get in to a endles loop of constantly rebuilding the set and it never gets to serving the set. If you do ‘npm rund build’ and then ‘npm run serve’ stil works.
The problem seems to be that when you build the set a javascript version of the interactions gets stored in src/interactions. And because nodemon is watching the src directory when you do ‘npm run dev’ is sees the creation of the javascript file as a file change and restarts the build process and that creates the file again. So it’s a endless loop.

This just solves the surface problem but i think the creation of the js files for interactions should be removed because it clutters the src/interaction directory