### PR TITLE
feat: add custom model attribute to build validation

### DIFF
--- a/src/validations/constants.ts
+++ b/src/validations/constants.ts
@@ -100,6 +100,7 @@ export const OPTIONS = [
   'COLOR',
   'CUSTOM',
   'CUSTOM_MODEL',
+  'CUSTOM_MODEL_ATTRIBUTE',
   'DROPDOWN',
   'ENDPOINT',
   'FILTER',

--- a/src/validations/prefab.ts
+++ b/src/validations/prefab.ts
@@ -35,6 +35,7 @@ const componentReferenceSchema = Joi.object({
               value: Joi.string(),
             }),
           ),
+          allowedTypes: Joi.array().items(Joi.string()),
           as: Joi.string(),
           component: Joi.string(),
           condition: Joi.object({


### PR DESCRIPTION
This will add the custom model attribute type and the allowedtypes key in the configuration.