### PR TITLE
feat: add DecimalInputIcon

### DIFF
--- a/src/validations/constants.ts
+++ b/src/validations/constants.ts
@@ -31,6 +31,7 @@ export const ICONS = [
   'DataTableRow',
   'DatePickerIcon',
   'DateTimePickerIcon',
+  'DecimalInputIcon',
   'DefinitionListIcon',
   'DialogIcon',
   'DrawerIcon',


### PR DESCRIPTION
This `DecimalInputIcon` is used for the new `DecimalInput` prefab ([Link to the related Jira ticket](https://bettyblocks.atlassian.net/browse/TA-1897?atlOrigin=eyJpIjoiYjM1NTIyOTQwODY5NDQyOGFjNTY3YjU4YzRkNzFjYWUiLCJwIjoiaiJ9)) and needs to be added to the validations in order for the set to build with the new prefab. 

