### PR TITLE
fix: windows support with building json

### DIFF
--- a/src/components/compatibility.ts
+++ b/src/components/compatibility.ts
@@ -117,8 +117,9 @@ export default (code: string): ComponentCompatibility => {
     transformers: { before: [compatibilityTransformer()] },
   });
 
-  const { length } = outputText;
-  const component = JSON.parse(outputText.slice(1, length - 3));
+  const component = JSON.parse(
+    outputText.replace(/^[^{]+/, '').replace(/[^}]+$/, ''),
+  );
 
   if (isComponentCompatibility(component)) {
     return component;

--- a/src/interactions/compatibility.ts
+++ b/src/interactions/compatibility.ts
@@ -251,8 +251,9 @@ export default (code: string): Interaction => {
     transformers: { before: [compatibilityTransformer()] },
   });
 
-  const { length } = outputText;
-  const interaction = JSON.parse(outputText.slice(1, length - 3));
+  const interaction = JSON.parse(
+    outputText.replace(/^[^{]+/, '').replace(/[^}]+$/, ''),
+  );
 
   if (isInteraction(interaction)) {
     return interaction;


### PR DESCRIPTION
Different line endings probably caused the resulting string to have 4 characters at the end before the json } bracket. Instead of 3 breaking json parsing on windows.

With this change test and yarn build now succeed on windows.

https://github.com/bettyblocks/material-ui-component-set/issues/357