### PR TITLE
fix: allow empty string for variable name

### DIFF
--- a/src/validations/prefab/variable.ts
+++ b/src/validations/prefab/variable.ts
@@ -27,7 +27,9 @@ export const variableKindSchema = Joi.when('kind', {
 });
 
 export const variableSchema = Joi.object({
-  name: Joi.string().required(),
+  name: Joi.string()
+    .allow('')
+    .required(),
   kind: Joi.string()
     .valid(...VARIABLE_KIND)
     .required(),


### PR DESCRIPTION
  - You can now assign an empty string as a variable name