### PR TITLE
fix: unable to reload v2 property option page 787

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To install the CLI you will need [a recent version of Node.js](https://nodejs.org/en/).
 
 ```bash
-$ npm install -g @betty-blocks/cli@23
+$ npm install -g @betty-blocks/cli
 ```
 
 ## Introduction

--- a/src/validations/prefab/componentOption.ts
+++ b/src/validations/prefab/componentOption.ts
@@ -54,6 +54,7 @@ const optionConfigurationSchema = Joi.when('type', {
     ...optionConfigurationSchemaBase,
     apiVersion: Joi.string()
       .pattern(/^v[\d]{1,}/)
+      .invalid('v1')
       .default('v2'),
   }),
   otherwise: Joi.object(optionConfigurationSchemaBase),

--- a/src/validations/prefab/componentOption.ts
+++ b/src/validations/prefab/componentOption.ts
@@ -55,7 +55,10 @@ const optionConfigurationSchema = Joi.when('type', {
     apiVersion: Joi.string()
       .pattern(/^v[\d]{1,}/)
       .invalid('v1')
-      .default('v2'),
+      .default('v2')
+      .messages({
+        'any.invalid': 'API version 1 is no longer supported.',
+      }),
   }),
   otherwise: Joi.object(optionConfigurationSchemaBase),
 }).default({});

--- a/src/validations/prefab/componentOption.ts
+++ b/src/validations/prefab/componentOption.ts
@@ -19,8 +19,10 @@ const refSchema = Joi.when('type', {
   otherwise: Joi.forbidden(),
 });
 
-const optionConfigurationSchema = Joi.object({
-  apiVersion: Joi.string(),
+const optionConfigurationSchemaBase = {
+  apiVersion: Joi.string()
+    .pattern(/^v[\d]{1,}/)
+    .default('v1'),
   allowedInput: Joi.array().items(
     Joi.object({
       name: Joi.string().allow(''),
@@ -44,7 +46,18 @@ const optionConfigurationSchema = Joi.object({
     generateCustomModel: Joi.boolean(),
     modelRequired: Joi.boolean(),
   }),
-});
+};
+
+const optionConfigurationSchema = Joi.when('type', {
+  is: 'PROPERTY',
+  then: Joi.object({
+    ...optionConfigurationSchemaBase,
+    apiVersion: Joi.string()
+      .pattern(/^v[\d]{1,}/)
+      .default('v2'),
+  }),
+  otherwise: Joi.object(optionConfigurationSchemaBase),
+}).default({});
 
 export const optionSchema = Joi.object({
   label: Joi.string().required(),


### PR DESCRIPTION
Add default `apiVersion` for component options
Add validation on `apiVersion`