### PR TITLE
feat: reword application id prompt

### DIFF
--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -81,7 +81,7 @@ class Config {
       {
         type: 'text',
         name: 'applicationId',
-        message: `Please supply the ID for your application (${identifier} ${zone})`,
+        message: `Please provide the UUID for '${identifier}' (${zone})`,
       },
     ])) as { applicationId: string };
 


### PR DESCRIPTION
To make it a bit more clear that we require the UUID instead of the identifier.