### PR TITLE
Feat/add option categories page 1732

### DIFF
--- a/__tests__/utils/validation.test.ts
+++ b/__tests__/utils/validation.test.ts
@@ -1,0 +1,57 @@
+import test, { ExecutionContext } from 'ava';
+
+import { checkOptionCategoryReferences } from '../../src/utils/validation';
+import type { Prefab } from '../../src/types';
+
+type Context = ExecutionContext<unknown>;
+
+test('Throws when option category references do not match an option', (t: Context): void => {
+  const prefabs = [
+    {
+      name: 'Component name',
+      icon: 'TitleIcon',
+      category: 'CONTENT',
+      structure: [
+        {
+          type: 'WRAPPER',
+          optionCategories: [{ label: 'Category 2', members: ['foo'] }],
+          options: [
+            {
+              key: '0',
+              type: 'LINKED_OPTION',
+              value: {
+                ref: {
+                  componentId: '#textComponent',
+                  optionId: '#textOption',
+                },
+              },
+            },
+          ],
+          descendants: [
+            {
+              ref: {
+                id: '#textComponent',
+              },
+              name: 'Text',
+              optionCategories: [{ label: 'Category 1', members: ['foo'] }],
+              options: [
+                {
+                  ref: {
+                    id: '#textOption',
+                  },
+                  value: '',
+                  label: 'something',
+                  key: 'option1',
+                  type: 'TEXT',
+                },
+              ],
+              descendants: [],
+            },
+          ],
+        },
+      ],
+    },
+  ] as unknown as Prefab[];
+
+  t.throws(() => checkOptionCategoryReferences(prefabs));
+});

--- a/__tests__/validations/component.test.tsx
+++ b/__tests__/validations/component.test.tsx
@@ -318,25 +318,90 @@ test('Does not throw when nesting wrapper objects', (t: Context): void => {
   t.notThrows(() => validatePrefabs(prefabs));
 });
 
-test('Does throw when wrapper has options (linked options not supported yet)', (t: Context): void => {
+test('Does not throw when component option categories are valid', (t: Context): void => {
   const prefabs = [
     {
-      name: 'Component Name',
+      name: 'Component name',
+      icon: 'TitleIcon',
+      category: 'CONTENT',
+      structure: [
+        {
+          name: 'Text',
+          optionCategories: [
+            { label: 'Category 1', members: ['option1'] },
+            { label: 'Category 2', members: ['option2'] },
+          ],
+          options: [
+            {
+              value: '',
+              label: 'something',
+              key: 'option1',
+              type: 'TEXT',
+            },
+            {
+              value: '',
+              label: 'something',
+              key: 'option2',
+              type: 'TEXT',
+            },
+          ],
+          descendants: [],
+        },
+      ],
+    },
+  ] as unknown as Prefab[];
+
+  t.notThrows(() => validatePrefabs(prefabs));
+});
+
+test('Does not throw when wrapper option categories are valid', (t: Context): void => {
+  const prefabs = [
+    {
+      name: 'Component name',
       icon: 'TitleIcon',
       category: 'CONTENT',
       structure: [
         {
           type: 'WRAPPER',
+          optionCategories: [{ label: 'Category 1', members: ['0'] }],
           options: [
             {
-              type: "LINKED",
+              key: '0',
+              type: 'LINKED_OPTION',
               value: {
                 ref: {
                   componentId: '#componentId1',
-                  optionId: '#componentId1OptionId1'
-                }
-              }
-            }
+                  optionId: '#componentId1OptionId1',
+                },
+              },
+            },
+          ],
+          descendants: [],
+        },
+      ],
+    },
+  ] as unknown as Prefab[];
+
+  t.notThrows(() => validatePrefabs(prefabs));
+});
+
+test('Throws when component option category has no label', (t: Context): void => {
+  const prefabs = [
+    {
+      name: 'Component name',
+      icon: 'TitleIcon',
+      category: 'CONTENT',
+      structure: [
+        {
+          name: 'Text',
+          optionCategories: [{ members: ['option1'] }],
+          options: [
+            {
+              value: '',
+              label: 'something',
+              key: 'option1',
+              type: 'TEXT',
+            },
           ],
           descendants: [],
         },
@@ -347,40 +412,79 @@ test('Does throw when wrapper has options (linked options not supported yet)', (
   t.throws(() => validatePrefabs(prefabs));
 });
 
-test('Does throw when a wrapper nested in the structure has options (linked options not supported yet)', (t: Context): void => {
+test('Throws when component option category has no entries', (t: Context): void => {
   const prefabs = [
     {
-      name: 'Component Name',
+      name: 'Component name',
       icon: 'TitleIcon',
       category: 'CONTENT',
       structure: [
         {
-          name: 'something',
+          name: 'Text',
+          optionCategories: [],
           options: [
             {
               value: '',
               label: 'something',
-              key: 'something',
+              key: 'option1',
               type: 'TEXT',
             },
           ],
-          descendants: [
+          descendants: [],
+        },
+      ],
+    },
+  ] as unknown as Prefab[];
+
+  t.throws(() => validatePrefabs(prefabs));
+});
+
+test('Throws when component option category members has no entries', (t: Context): void => {
+  const prefabs = [
+    {
+      name: 'Component name',
+      icon: 'TitleIcon',
+      category: 'CONTENT',
+      structure: [
+        {
+          name: 'Text',
+          optionCategories: [{ label: 'Category 1', members: [] }],
+          options: [
             {
-              type: 'WRAPPER',
-              options: [
-                {
-                  type: "LINKED",
-                  value: {
-                    ref: {
-                      componentId: '#componentId1',
-                      optionId: '#componentId1OptionId1'
-                    }
-                  }
-                }
-              ],
-              descendants: [],
+              value: '',
+              label: 'something',
+              key: 'option1',
+              type: 'TEXT',
             },
           ],
+          descendants: [],
+        },
+      ],
+    },
+  ] as unknown as Prefab[];
+
+  t.throws(() => validatePrefabs(prefabs));
+});
+
+test('Throws when component option category member does not match option key', (t: Context): void => {
+  const prefabs = [
+    {
+      name: 'Component name',
+      icon: 'TitleIcon',
+      category: 'CONTENT',
+      structure: [
+        {
+          name: 'Text',
+          optionCategories: [{ label: 'Category 1', members: ['foo'] }],
+          options: [
+            {
+              value: '',
+              label: 'something',
+              key: 'option1',
+              type: 'TEXT',
+            },
+          ],
+          descendants: [],
         },
       ],
     },
@@ -600,7 +704,6 @@ test('Dont throw when prefab component option has a ref', (t: Context): void => 
   validatePrefabs(prefabs);
   t.pass();
 });
-
 
 test('Throw when the prefabs option type is not referring to one the correct types', (t: Context): void => {
   const prefabs = [

--- a/__tests__/validations/component.test.tsx
+++ b/__tests__/validations/component.test.tsx
@@ -466,33 +466,6 @@ test('Throws when component option category members has no entries', (t: Context
   t.throws(() => validatePrefabs(prefabs));
 });
 
-test('Throws when component option category member does not match option key', (t: Context): void => {
-  const prefabs = [
-    {
-      name: 'Component name',
-      icon: 'TitleIcon',
-      category: 'CONTENT',
-      structure: [
-        {
-          name: 'Text',
-          optionCategories: [{ label: 'Category 1', members: ['foo'] }],
-          options: [
-            {
-              value: '',
-              label: 'something',
-              key: 'option1',
-              type: 'TEXT',
-            },
-          ],
-          descendants: [],
-        },
-      ],
-    },
-  ] as unknown as Prefab[];
-
-  t.throws(() => validatePrefabs(prefabs));
-});
-
 test('Does not throw when button prefabs style override options are valid', (t: Context): void => {
   const prefabs = [
     {

--- a/src/bb-components-build.ts
+++ b/src/bb-components-build.ts
@@ -23,7 +23,10 @@ import { checkUpdateAvailableCLI } from './utils/checkUpdateAvailable';
 import hash from './utils/hash';
 import readFilesByType from './utils/readFilesByType';
 import transpile from './utils/transpile';
-import { checkNameReferences } from './utils/validation';
+import {
+  checkNameReferences,
+  checkOptionCategoryReferences,
+} from './utils/validation';
 import validateComponents from './validations/component';
 import validateInteractions from './validations/interaction';
 import validatePrefabs from './validations/prefab';
@@ -330,6 +333,8 @@ void (async (): Promise<void> => {
       validatePrefabs(partialprefabs, componentStyleMap, 'partial'),
       interactions && validateInteractions(interactions),
     ]);
+
+    checkOptionCategoryReferences(prefabs);
 
     const componentsWithHash = components.map((component) => {
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type PrefabPartial = {
 export type PrefabWrapper = {
   type: 'WRAPPER';
   descendants: PrefabReference[];
+  optionCategories?: PrefabComponentOptionCategory[];
   options: PrefabComponentOption[];
 };
 export interface PrefabComponent {
@@ -98,6 +99,7 @@ export interface PrefabComponent {
     };
   };
   descendants: PrefabReference[];
+  optionCategories?: PrefabComponentOptionCategory[];
   options: PrefabComponentOption[];
   ref?: {
     id: string;
@@ -131,6 +133,12 @@ export interface ValueRef {
     value: string;
   };
 }
+
+export type PrefabComponentOptionCategory = {
+  label: string;
+  extended?: boolean;
+  members: string[];
+};
 
 export type PrefabComponentOption = PrefabComponentOptionBase &
   (ValueDefault | ValueRef);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -94,3 +94,37 @@ export const checkNameReferences = (
     structure.forEach(checkComponentReferenceNames(componentNames, name));
   });
 };
+
+export function checkOptionCategoryReferences(prefabs: Prefab[]): void {
+  function innerFn(structure: PrefabReference[], name: string): void {
+    structure.forEach((prefabReference) => {
+      if (
+        prefabReference.type === undefined ||
+        prefabReference.type === 'COMPONENT' ||
+        prefabReference.type === 'WRAPPER'
+      ) {
+        if (prefabReference?.optionCategories) {
+          prefabReference.optionCategories.forEach((category) => {
+            category.members.forEach((member) => {
+              if (
+                !prefabReference.options.some((option) => member === option.key)
+              ) {
+                throw new Error(
+                  chalk.red(
+                    `\nOption category member: "${member}" references to non-existing option\n\nat prefab: ${name}`,
+                  ),
+                );
+              }
+            });
+          });
+        }
+
+        innerFn(prefabReference.descendants, name);
+      }
+    });
+  }
+
+  prefabs.forEach((prefab) => {
+    innerFn(prefab.structure, prefab.name);
+  });
+}

--- a/src/validations/prefab/component.ts
+++ b/src/validations/prefab/component.ts
@@ -104,6 +104,7 @@ const wrapperSchema = (
   return Joi.object({
     type: Joi.string().valid('WRAPPER').required(),
     label: Joi.string(),
+    optionCategories: Joi.array().items(optionCategorySchema).min(1),
     options: Joi.array().items(linkedOptionSchema).required(),
     descendants: Joi.array()
       .items(Joi.custom(validateComponent(componentStyleMap, prefabType)))

--- a/src/validations/prefab/component.ts
+++ b/src/validations/prefab/component.ts
@@ -11,7 +11,11 @@ import {
   PrefabReference,
 } from '../../types';
 import { findDuplicates } from '../../utils/validation';
-import { optionSchema, linkedOptionSchema } from './componentOption';
+import {
+  optionCategorySchema,
+  optionSchema,
+  linkedOptionSchema,
+} from './componentOption';
 
 type StyleValidator = Record<Component['styleType'], Joi.ObjectSchema>;
 type PrefabTypes = 'partial' | 'page' | undefined;
@@ -124,6 +128,7 @@ const componentSchema = (
     ref: Joi.object({
       id: Joi.string().required(),
     }),
+    optionCategories: Joi.array().items(optionCategorySchema).min(1),
     options: Joi.array().items(optionSchema).required(),
     type: Joi.string().valid('COMPONENT').default('COMPONENT'),
     descendants: Joi.array()

--- a/src/validations/prefab/componentOption.ts
+++ b/src/validations/prefab/componentOption.ts
@@ -111,3 +111,9 @@ export const optionSchema = Joi.object({
   }),
   ref: refSchema,
 });
+
+export const optionCategorySchema = Joi.object({
+  label: Joi.string().required(),
+  expanded: Joi.boolean(),
+  members: Joi.array().items(Joi.string()).min(1).required(),
+});


### PR DESCRIPTION
**What does this PR do?**

* Validates the `optionCategories` key on prefab component and wrapper references