### PR TITLE
Reverse transpiledFunction with compatibility object, so that the triggers key doesn't get overwritten

### DIFF
--- a/src/bb-components-build.ts
+++ b/src/bb-components-build.ts
@@ -88,8 +88,8 @@ const readComponents: () => Promise<Component[]> = async (): Promise<
         }
 
         return {
-          ...transpiledFunction,
           ...compatibility,
+          ...transpiledFunction,
         };
       } catch (error) {
         error.file = file;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4759,7 +4759,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz"
 
-npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-package-arg@^8.1.2, npm-package-arg@^8.1.4, npm-package-arg@^8.1.5:
+npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-package-arg@^8.1.1, npm-package-arg@^8.1.2, npm-package-arg@^8.1.5:
   version "8.1.5"
   resolved "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz"
   integrity sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==
@@ -5175,7 +5175,7 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-pacote@^11.1.11, pacote@^11.2.6, pacote@^11.3.1, pacote@^11.3.4, pacote@^11.3.5:
+pacote@^11.1.11, pacote@^11.2.6, pacote@^11.3.0, pacote@^11.3.1, pacote@^11.3.5:
   version "11.3.5"
   resolved "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz"
   integrity sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==


### PR DESCRIPTION
For the new pagebuilder runtime setup, users can now add their own custom triggers to their components like so:
```javascript
(() => ({
  name: 'Button',
  // ...
  triggers: ['Click'],
  jsx: (() => {
    return (
        <button
          onClick={() => {
            triggers && triggers.Click && triggers.Click();
          }}
        >
          {options.text}
        </button>
    );
  })(),
}))();
```
On build, the `transpiledFunction` object contains the triggers property, but it gets overwritten by the `compatibility` object, as this contains `triggers: []` by default.

spreading the `transpiledFunction` after spreading the `compatibility` object fixes this problem.