### PR TITLE
fix: filter non-prefabs from prefabs-list

### DIFF
--- a/src/bb-components-build.ts
+++ b/src/bb-components-build.ts
@@ -343,7 +343,9 @@ void (async (): Promise<void> => {
     ]);
 
     const validStyleTypes = styles.map(({ type }) => type);
-    const prefabs = jsPrefabs.concat(tsxPrefabs);
+    const prefabs = jsPrefabs
+      .concat(tsxPrefabs)
+      .filter((prefab): prefab is Prefab => !!prefab);
 
     const stylesGroupedByTypeAndName = styles.reduce<GroupedStyles>(
       (object, e) => {


### PR DESCRIPTION
The compiler processes too many files, and will always request the exported function in its results.
When a file does not export that function, it will return a `undefined` instead.

So filter the output for non-prefabs, before passing it to the validation-functions.