### PR TITLE
feat: add disabledNames to property options to disable these properties

### DIFF
--- a/__tests__/validations/component.test.tsx
+++ b/__tests__/validations/component.test.tsx
@@ -941,6 +941,7 @@ test('Success when the reconfigure configuration options of the prefabs are vali
               type: 'PROPERTY',
               configuration: {
                 allowedKinds: ['TEXT', 'URL'],
+                disabledNames: ['id', 'created_at', 'updated_at'],
                 createProperty: {
                   type: 'TEXT',
                   value: 'New property',

--- a/src/validations/prefab/componentOption.ts
+++ b/src/validations/prefab/componentOption.ts
@@ -75,6 +75,7 @@ const optionConfigurationSchema = Joi.when('type', {
         'any.invalid': 'API version 1 is no longer supported.',
       }),
     allowedKinds: Joi.array().items(Joi.string()),
+    disabledNames: Joi.array().items(Joi.string()),
     allowedSplitButtonKinds: Joi.array().items(Joi.string()),
     allowedClickThroughKinds: Joi.array().items(Joi.string()),
     createProperty: Joi.object({


### PR DESCRIPTION
When using a dateTime property option for an **input component**, we don't want the business technologist to select the updated_at and created_at properties, because you cannot override them.